### PR TITLE
small typo in README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ Install the package:
 
 ```{r eval=FALSE}
 library("devtools")
-install_github("cboettig/pmc2")
+install_github("cboettig/pmc")
 ```
 
 A trivial example with data simulated from the `lambda` model. 


### PR DESCRIPTION
`pmc2` is a typo I think (https://github.com/cboettig/pmc2 goes nowhere)